### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ List available optional features
 Auto-detect everything
 
     $ ./configure
+    
+If you get a 'configure failed' error, run
+
+    $ sudo apt-get install libncurses5-dev
 
 To disable some feature, arts for example, and install to $HOME run
 


### PR DESCRIPTION
This pull request is to implement the fix suggested in the issue #6 

If a user doesn't have the development version of ncurses installed (libncurses5-dev), they will get a `configure failed` error. The readme has been updated with a solution.